### PR TITLE
feat: Improve cls args types

### DIFF
--- a/src/dom/cls.ts
+++ b/src/dom/cls.ts
@@ -7,9 +7,11 @@
  *
  *    cls("a", "b") // "a b"
  *    cls(false && "a", "b") // "b"
+ *    cls(undefined && "a", "b") // "b"
+ *    cls(null && "a", "b") // "b"
  *
  * @param classes
  */
-export function cls(...classes: (boolean | string)[]): string {
+export function cls(...classes: (string | boolean | null | undefined)[]): string {
   return classes?.filter(Boolean).join(" ")
 }

--- a/tests/dom/cls.test.ts
+++ b/tests/dom/cls.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { cls } from "../../src/dom/cls"
+import { cls } from "../../src"
 
 describe("cls", () => {
   it("should compose cls list", () => {
@@ -19,5 +19,8 @@ describe("cls", () => {
     expect(cls(false && "foo")).toBe("")
     expect(cls(undefined)).toBe("")
     expect(cls(null)).toBe("")
+
+    const className: string | undefined = "Test"
+    expect(cls(className)).toBe(className)
   })
 })


### PR DESCRIPTION
Update `cls` function params witch can now received `string | boolean | null | undefined`